### PR TITLE
Fix Dialog Alignment

### DIFF
--- a/app/views/lists/_list_form.html.erb
+++ b/app/views/lists/_list_form.html.erb
@@ -4,6 +4,8 @@
     class="w-full
            md:w-1/2
            p-4
+           self-center
+           justify-self-center
            dark:bg-zinc-950
            dark:text-zinc-50
            rounded-lg

--- a/app/views/lists/_lists.html.erb
+++ b/app/views/lists/_lists.html.erb
@@ -9,6 +9,8 @@
           <dialog
             data-dialog-target="dialog"
             class="p-4
+                   self-center
+                   justify-self-center
                    dark:bg-zinc-950
                    dark:text-zinc-50
                    rounded

--- a/app/views/lists/_todo_form.html.erb
+++ b/app/views/lists/_todo_form.html.erb
@@ -5,6 +5,8 @@
             class="w-full
                   md:w-1/2
                   p-4
+                  self-center
+                  justify-self-center
                   dark:bg-zinc-950
                   dark:text-zinc-50
                   rounded-lg
@@ -91,6 +93,8 @@
     <dialog
       data-dialog-target="dialog"
       class="p-4
+             self-center
+             justify-self-center
              dark:bg-zinc-950
              dark:text-zinc-50
              rounded


### PR DESCRIPTION
This pull request introduces changes to the styling of various elements in the `lists` views to improve their alignment and centering. The most important changes include adding `self-center` and `justify-self-center` classes to the elements.

Styling improvements:

* [`app/views/lists/_list_form.html.erb`](diffhunk://#diff-13efac69f0524919ecccde309f28f03ebee7ed846086b9f5224751a3eb936f05R7-R8): Added `self-center` and `justify-self-center` classes to the form container for better centering.
* [`app/views/lists/_lists.html.erb`](diffhunk://#diff-66969761ba7f852ec9b5977292752493b338989f37cc211bdb6637ef3ab1b30cR12-R13): Added `self-center` and `justify-self-center` classes to the dialog element for improved alignment.
* [`app/views/lists/_todo_form.html.erb`](diffhunk://#diff-ec69df3272c0e64da024fec952bcf6cd530f84ac15fb5271569d6919df5bddedR8-R9): Added `self-center` and `justify-self-center` classes to both the form container and the dialog element for consistent centering. [[1]](diffhunk://#diff-ec69df3272c0e64da024fec952bcf6cd530f84ac15fb5271569d6919df5bddedR8-R9) [[2]](diffhunk://#diff-ec69df3272c0e64da024fec952bcf6cd530f84ac15fb5271569d6919df5bddedR96-R97)